### PR TITLE
Add support for encryption enabled s3 bucket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,104 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+.static_storage/
+.media/
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # s3werkzeugcache
+
+
+Following is an example of use of s3cache for a server side encryption enabled bucket
+```
+  bucket = 'test-bucket'
+
+  put_extra_args = {'ServerSideEncryption': 'AES256'}
+  cache = S3Cache(bucket, 'cache_test/', put_extra_args=put_extra_args)
+  cache.add('name', 's3cache')
+  val = cache.get('name')
+  print(val)
+```

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '0.1.0.1'
+version = '0.1.0.2'
 
 setup(
     name='s3werkzeugcache',
@@ -17,7 +17,7 @@ setup(
     ],
     author='Bogdan Kyryliuk',
     author_email='b.kyryliuk@gmail.com',
-    url='https://git.musta.ch/bogdan-kyryliuk/s3cache',
+    url='https://github.com/bkyryliuk/s3werkzeugcache',
     download_url=(
         'https://github.com/bogdan-kyryliuk/s3cache/tarball/' + version),
     classifiers=[


### PR DESCRIPTION
Support for additional arguments in the constructor allows for use of [encrypted bucket](http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html) etc:

```  
  bucket = 'test-bucket'

  put_extra_args = {'ServerSideEncryption': 'AES256'}
  cache = S3Cache(bucket, 'cache_test/', put_extra_args=put_extra_args)
  cache.add('name', 's3cache')
  val = cache.get('name')
  print(val)
...
s3cache
```
