### PR TITLE
Removing dependency on flask-cache

### DIFF
--- a/s3cache/s3cache.py
+++ b/s3cache/s3cache.py
@@ -1,6 +1,6 @@
 """Results backends are used to store long-running query results
 
-The Abstraction is flask-cache, which uses the BaseCache class from werkzeug
+The Abstraction is flask-caching, which uses the BaseCache class from werkzeug
 """
 from __future__ import absolute_import
 from __future__ import division

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ setup(
     zip_safe=False,
     install_requires=[
         'boto3',
-        'flask-cache',
         'werkzeug',
     ],
     author='Bogdan Kyryliuk',


### PR DESCRIPTION
flask-cache is deprecated in favor of flask-caching. Apparently though
flask-cache is not actually used in this repository.