### PR TITLE
Migrate from werkzeug to cachelib

### DIFF
--- a/s3cache/s3cache.py
+++ b/s3cache/s3cache.py
@@ -1,6 +1,6 @@
 """Results backends are used to store long-running query results
 
-The Abstraction is flask-caching, which uses the BaseCache class from werkzeug
+The Abstraction is flask-caching, which uses the BaseCache class from cachelib
 """
 from __future__ import absolute_import
 from __future__ import division
@@ -16,7 +16,7 @@ import io
 import logging
 
 import boto3
-from werkzeug.contrib.cache import BaseCache
+from cachelib import BaseCache
 
 
 class S3Cache(BaseCache):

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'boto3',
-        'werkzeug',
+        'cachelib',
     ],
     author='Bogdan Kyryliuk',
     author_email='b.kyryliuk@gmail.com',


### PR DESCRIPTION
As titled, this is required because Superset upgraded to werkzeug 1.0, which removed the cache functionality into a new library. Not sure if this code is going to work, but will test within superset soon.

cc: @villebro, @bkyryliuk, @mistercrunch, @john-bodley